### PR TITLE
Register Test::Pod::LinkCheck as a develop phase prereq

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Dist-Zilla-Plugin-Test-Pod-LinkCheck
 
 {{$NEXT}}
 
+  - Add Test::Pod::LinkCheck as a develop phase prereq on distros which use
+    this plugin. GH #1 (Dave Rolsky)
+
+
 1.001     2011-07-14T23:49:41Z
 
   - Superficial dist/release changes

--- a/lib/Dist/Zilla/Plugin/Test/Pod/LinkCheck.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Pod/LinkCheck.pm
@@ -7,6 +7,19 @@ package Dist::Zilla::Plugin::Test::Pod::LinkCheck;
 
 use Moose;
 extends 'Dist::Zilla::Plugin::InlineFiles';
+with 'Dist::Zilla::Role::PrereqSource';
+
+sub register_prereqs {
+  my $self = shift;
+
+  $self->zilla->register_prereqs(
+    {
+        type  => 'requires',
+        phase => 'develop',
+    },
+    'Test::Pod::LinkCheck' => '0',
+  );
+}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;


### PR DESCRIPTION
This causes any distro which uses this plugin to include this prereq in its META.\* files. This is important for the travis-perl helpers and is just generally more correct.
